### PR TITLE
Fix some minor typos

### DIFF
--- a/doc/accelerator-adapter.md
+++ b/doc/accelerator-adapter.md
@@ -42,7 +42,7 @@ The `acc_adapter` module variation additionally requires the accordingly generat
 
   The typedefs are automatically declared using the typedef macros defined [here](../include/acc_interface/typedef.svh) as demonstrated in the following snippet.
 
-```
+```sv
   typedef logic [AddrWidth-1:0] addr_t; // AddrWidth parameter as defined in doc/c-interface.md.
   typedef logic [DataWidth-1:0] data_t;
 
@@ -54,7 +54,7 @@ The `acc_adapter` module variation additionally requires the accordingly generat
 The accelerator adapter module featuresthe following ports:
 | Interface Name (`acc_adapter_intf`) | Port Name (`acc_adapter`) | Type (`acc_adapter`)     | Description                                                        |
 | ---------                           | ---------                 | ----                     | -----------                                                        |
-| `hart_id_i`                         | `hart_id_i`               | `logic [DataWdth-1:0]`   | RISC-V hardware threat ID (hart id)                                |
+| `hart_id_i`                         | `hart_id_i`               | `logic [DataWdth-1:0]`   | RISC-V hardware thread ID (hart id)                                |
 | `acc_x_slv`                         | `acc_x_slv_req_i`         | `acc_x_req_t`            | X-interface request channel input from offloading CPU              |
 |                                     | `acc_x_slv_rsp_o`         | `acc_x_rsp_t`            | X-interface response channel output to offloading CPU              |
 | `acc_xmem_mst`                      | `acc_xmem_mst_req_o`      | `acc_xmem_req_t`         | XMem-interface request channel output to offloading CPU            |

--- a/doc/accelerator-interconnect.md
+++ b/doc/accelerator-interconnect.md
@@ -1,8 +1,8 @@
 # Accelerator Interconnect Module Specification
 The accelerator interconnect module implements the interconnect fabric on each level of the interconnect hierarchy.
-It comprises a crossbar for routing of requests and responses from a number of requesting units the accelerator structures residing on the corresponding interconnect level, as well as a bypass-path to forward requests from and to a higher hierarchy level.
-All in- and output ports implement the [C-interface](c-interface.md).
-For request and response path, separate pipeline registers may be implemented for each interconnect module.
+It comprises a crossbar for routing of requests and responses from a number of requesting units the accelerator structures residing on the corresponding interconnect level, as well as a bypass path to forward requests from and to a higher hierarchy level.
+All input and output ports implement the [C-interface](c-interface.md).
+For request and response paths, separate pipeline registers may be implemented for each interconnect module.
 
 ![Accelerator Interconnect Level](img/acc-interconnect-level.svg)
 
@@ -15,7 +15,7 @@ For request and response path, separate pipeline registers may be implemented fo
 The accelerator interconnect module (`acc_interconnect`) is parameterized as follows.
 
 | Name            | Type / Range        | Description                                           |
-| ----            | ------------        | -----------                                           |
+| --------------- | ------------------- | ----------------------------------------------------- |
 | `DataWidth`     | `int` (32, 64, 128) | ISA bit-width                                         |
 | `HierLevel`     | `int` (>=0)         | Hierarchy level                                       |
 | `HierAddrWidth` | `int` (>=1)         | Hierarchy address portion                             |
@@ -27,13 +27,13 @@ The accelerator interconnect module (`acc_interconnect`) is parameterized as fol
 
 - The `acc_interconnect_intf` module variation additionally requires the following parameters for internal definition of the request/response structs:
   | Name            | Type  | Description                                |
-  | ----            | ----  | -----------                                |
+  | --------------- | ----- | ------------------------------------------ |
   | `DualWriteback` | `bit` | Support for dual-writeback instructions    |
   | `TernaryOps`    | `bit` | Support for ternary operations (use `rs3`) |
 
 - The `acc_interconnect` module variation additionally requires the accordingly generated request/response struct types:
   | Name             | Description                    |
-  | ----             | -----------                    |
+  | ---------------- | ------------------------------ |
   | `acc_c_req_t`    | C-interface request struct     |
   | `acc_c_rsp_t`    | C-interface response struct    |
   | `acc_cmem_req_t` | CMem-interface request struct  |
@@ -41,7 +41,7 @@ The accelerator interconnect module (`acc_interconnect`) is parameterized as fol
 
   The typedefs are automatically declared using the typedef macros defined [here](../include/acc_interface/typedef.svh) as demonstrated in the following snippet.
 
-  ```
+  ```sv
   localparam int unsigned NumRs = TernaryOps ? 3 : 2;
   localparam int unsigned NumWb = DualWriteback ? 2 : 1;
 
@@ -55,7 +55,7 @@ The accelerator interconnect module (`acc_interconnect`) is parameterized as fol
 The accelerator interconnect module features the following [C-interface](c-interface.md) ports:
 
 | Port Name (`acc_interconnect_intf`) | Port Name (`acc_interconnect`)   | Type (`acc_interconnect`) | Description                                                                               |
-| ---------                           | ----------                       | ---------                 | -----------                                                                               |
+| ----------------------------------- | -------------------------------- | ------------------------- | ----------------------------------------------------------------------------------------- |
 | `acc_c_slv[NumReq]`                 | `acc_c_slv_req_i[NumReq-1:0]`    | `acc_c_req_t`             | C-interface request channel input from accelerator adapter / lower-level interconnect     |
 |                                     | `acc_c_slv_rsp_o[NumReq-1:0]`    | `acc_c_rsp_t`             | C-interface response channel output to accelerator adapter / lower level interconnect     |
 | `acc_cmem_mst[NumReq]`              | `acc_cmem_mst_req_o[NumReq-1:0]` | `acc_cmem_req_t`          | CMem-interface request channel output to accelerator adapter / lower-level interconnect   |
@@ -67,4 +67,4 @@ The accelerator interconnect module features the following [C-interface](c-inter
 | `acc_c_mst[NumRsp]`                 | `acc_c_mst_req_o[NumRsp-1:0]`    | `acc_c_req_t`             | C-interface request channel output to directly connected accelerators                     |
 |                                     | `acc_c_mst_rsp_i[NumRsp-1:0]`    | `acc_c_rsp_t`             | C-interface response channel input from directly connected accelerators                   |
 | `acc_cmem_slv[NumReq]`              | `acc_cmem_slv_req_i[NumReq-1:0]` | `acc_cmem_req_t`          | CMem-interface request channel input from directly connected accelerators                 |
-|                                    | `acc_cmem_slv_rsp_o[NumReq-1:0]` | `acc_cmem_rsp_t`          | CMem-interface response channel output to directly connected accelerators                 |
+|                                     | `acc_cmem_slv_rsp_o[NumReq-1:0]` | `acc_cmem_rsp_t`          | CMem-interface response channel output to directly connected accelerators                 |

--- a/doc/accelerator-predecoder.md
+++ b/doc/accelerator-predecoder.md
@@ -17,14 +17,14 @@ The accelerator predecoder signals are:
 
 ### Request Channel
 | Signal Name    | Type          | Direction            | Description              |
-| -------------  | ----          | ----------           | -----------              |
+| -------------- | ------------- | -------------------- | ------------------------ |
 | `q_instr_data` | `logic[31:0]` | Adapter > Predecoder | RISC-V Instruction Data. |
 
 ### Response Channel
 The response channel signals are summarized in the SystemVerilog struct `prd_rsp_t`.
 
 | Signal Name   | Type          | Direction            | Description                                                                       |
-| -----------   | ----          | ---------            | -----------                                                                       |
+| ------------- | ------------- | -------------------- | --------------------------------------------------------------------------------- |
 | `p_accept`    | `logic`       | Predecoder > Adapter | Indicates valid instruction                                                       |
 | `p_writeback` | `logic [1:0]` | Predecoder > Adapter | Instruction writeback to `rd` (`p_writeback[0]`) and `rd + 1` (`p_writeback[1]`)  |
 | `p_use_rs`    | `logic [2:0]` | Predecoder > Adapter | Asserting `p_use_rs[i]` implies the instruction requires source register `rs[i]`. |
@@ -34,7 +34,7 @@ The response channel signals are summarized in the SystemVerilog struct `prd_rsp
 To support decoding arbitrary offload instructions, the following SystemVerilog struct `offload_instr_t` is defined.
 
 | Signal name  | Type           | Description                                                         |
-| -----------  | ----           | -----------                                                         |
+| ------------ | -------------- | ------------------------------------------------------------------- |
 | `instr_data` | `logic [31:0]` | Instruction data matching the offloaded instruction                 |
 | `instr_mask` | `logic [31:0]` | Bitmask, masking off decode-irrelevant bits of the instruction data |
 | `prd_rsp`    | `prd_rsp_t`    | Predefined predecoder response                                      |
@@ -42,7 +42,7 @@ To support decoding arbitrary offload instructions, the following SystemVerilog 
 The accelerator predecoder module is parameterized as follows:
 
 | Name                     | Type                        | Description                              |
-| ----                     | ------------                | -----------                              |
+| ------------------------ | --------------------------- | ---------------------------------------- |
 | `NumInstr`               | `int` (>=1)                 | Total number of offloadable instructions |
 | `OffloadInstr[NumInstr]` | `offload_instr_t[NumInstr]` | Offload instruction metadata             |
 

--- a/doc/c-interface.md
+++ b/doc/c-interface.md
@@ -6,7 +6,7 @@ The C-Interface implements signal routing from and to the accelerator units.
 The C-Interface features two independent decoupled channels for offloading requests and accelerator writeback.
 The C-Interface defines in total four independent decoupled channels communication between the accelerator adapter and the accelerator units.
 The C-Request and C-Response channels route instruction offloading requests and accelerator writeback responses.
-The CMem-Request and CMem-Reponse channels route memory transaction requests and responses.
+The CMem-Request and CMem-Response channels route memory transaction requests and responses.
 
 The C and CMem SystemVerilog interfaces are separately defined as independent entities.
 Request channel signals are prefixed with the letter `q`.
@@ -22,7 +22,7 @@ All transactions are handshaked according to the following scheme:
 The interface is parameterized using the following set of parameters.
 
 | Name              | Type / Range        | Description                                       |
-| ----              | ------------        | -----------                                       |
+| ----------------- | ------------------- | ------------------------------------------------- |
 | `DataWidth`       | `int` (32, 64, 128) | ISA Bit-width                                     |
 | `NumReq`          | `int` (>=1)         | Number of requesting entities                     |
 | `NumHier`         | `int` (>=1)         | Number of hierarchical interconnect levels        |
@@ -32,7 +32,7 @@ The interface is parameterized using the following set of parameters.
 
 #### Derived Parameters
 | Name            | Value                          | Description                                               |
-| ----            | -----                          | -----------                                               |
+| --------------- | ------------------------------ | --------------------------------------------------------- |
 | `MaxNumRsp`     | `max(NumRsp)`                  | Maximum number of responding entities per hierarchy level |
 | `HierAddrWidth` | `clog2(NumHier)`               | Hierarchy level address width                             |
 | `AccAddrWidth`  | `clog2(MaxNumRsp)`             | Accelerator address width                                 |
@@ -46,7 +46,7 @@ The interface is parameterized using the following set of parameters.
 The request channel interface signals are:
 
 | Signal Name       | Type                               | Direction             | Description                 |
-| -----------       | ----                               | ---------             | -----------                 |
+| ----------------- | ---------------------------------- | --------------------- | --------------------------- |
 | `q_addr`          | `logic [AddrWidth-1:AccAddrWidth]` | Adapter > Accelerator | Accelerator hierarchy level |
 |                   | `logic [AccAddrWidth-1:0]`         | Adapter > Accelerator | Accelerator address         |
 | `q_hart_id`       | `logic [DataWidth-1:0]`            | Adapter > Accelerator | Hart ID                     |
@@ -63,12 +63,12 @@ Notes:
 If a response is returned, the response channel carries the following signals:
 
 | Signal Name       | Range                   | Direction             | Description                                                                   |
-| -----------       | -----                   | ---------             | -----------                                                                   |
+| ----------------- | ----------------------- | --------------------- | ----------------------------------------------------------------------------- |
 | `p_hart_id`       | `logic [DataWidth-1:0]` | Accelerator > Adapter | Hart ID                                                                       |
 | `p_rd`            | `logic [4:0]`           | Accelerator > Adapter | Destination register address                                                  |
 | `p_data[NumWb:0]` | `logic [DataWidth-1:0]` | Accelerator > Adapter | Instruction response data                                                     |
 | `p_dualwb`        | `logic`                 | Accelerator > Adapter | Dual-Writeback Response (constant `1'b0`, if dual-writeback is not supported) |
-| `p_type`          | `logic`                 | Accelerator > Adapter | Response type
+| `p_type`          | `logic`                 | Accelerator > Adapter | Response type                                                                 |
 | `p_error`         | `logic`                 | Accelerator > Adapter | Error Flag                                                                    |
 
 Notes:
@@ -92,7 +92,7 @@ Notes:
 The request channel signals from the accelerator units to the accelerator adapter are:
 
 | Signal Name          | Type                               | Direction             | Description                                               |
-| -----------          | ----                               | ---------             | -----------                                               |
+| -------------------- | ---------------------------------- | --------------------- | --------------------------------------------------------- |
 | `q_hart_id`          | `logic [DataWidth-1:0]`            | Accelerator > Adapter | Hart ID                                                   |
 | `q_addr`             | `logic [AddrWidth-1:AccAddrWidth]` | Accelerator > Adapter | Accelerator hierarchy level                               |
 |                      | `logic [AccAddrWidth-1:0]`         | Accelerator > Adapter | Accelerator address                                       |
@@ -108,8 +108,8 @@ The request channel signals from the accelerator units to the accelerator adapte
 The response channel signals from the accelerator adapter to the accelerator unit are:
 
 | Signal Name  | Type                           | Direction             | Description                           |
-| -----------  | ----                           | ---------             | -----------                           |
-| `p_addr` | `logic [AddrWidth-1:0]`        | Adapter > Accelerator | Accelerator address                   |
+| ------------ | ------------------------------ | --------------------- | ------------------------------------- |
+| `p_addr`     | `logic [AddrWidth-1:0]`        | Adapter > Accelerator | Accelerator address                   |
 | `p_hart_id`  | `logic [DataWidth-1:0]`        | Adapter > Accelerator | Hart ID                               |
 | `p_rdata`    | `logic [DataWidth-1:0]`        | Adapter > Accelerator | Memory response data.                 |
 | `p_range`    | `logic [clog2(DataWidth)-1:0]` | Adapter > Accelerator | Validity LSB range of memory metadata |
@@ -119,7 +119,7 @@ Notes:
   - The response transaction status `p_status` field indicates the success (`p_status = 1'b1`) or failure (`p_status = 1'b0`) of the memory operation.
       - For standard requests, the status field indicates if the operation raised an access fault exception.
       - For probing memory requests, the status field indicates if the requested access has been granted.
-  - The `p_range` field carries information on the memory region querried with a probing memory request.
+  - The `p_range` field carries information on the memory region queried with a probing memory request.
     If the `p_status` field signals access has been granted, this field specifies the number of bits that can be changed in the logical address without changing the metadata
 
 ## Master/Slave Interface Ports

--- a/doc/index.md
+++ b/doc/index.md
@@ -58,8 +58,8 @@ The core-v-xif enables decoupled development of accelerators and CPU cores throu
 
 ### Dual-Writeback Instructions
 The core-v-xif optionally supports implementation of custom ISA extensions mandating dual register writebacks.
-In order to accomodate that need we provision the possibility to reserve multiple destination registers for a single offloaded instruction.
-For even destination registers other than `X0`,  `Xn` and `Xn+1` are reserved for writeback upon offloading a dual-writeback instruction, where `Xn` denotes the destination register addresss extracted from `instr_data[11:7]`.
+In order to accommodate that need we provision the possibility to reserve multiple destination registers for a single offloaded instruction.
+For even destination registers other than `X0`,  `Xn` and `Xn+1` are reserved for writeback upon offloading a dual-writeback instruction, where `Xn` denotes the destination register address extracted from `instr_data[11:7]`.
 
 ### Ternary Operations
 The core-v-xif optionally supports ISA extensions implementing instructions which use three source operands.
@@ -74,7 +74,7 @@ Any number of cores in a cluster can be connected to share a selection of accele
 
 ### Transaction Ordering
 The accelerator interconnect itself does not guarantee any response transaction ordering.
-The order in which offload requests are issued is determined by validity of source- and destination registers of the instruction to be offloaded.
+The order in which offload requests are issued is determined by validity of source and destination registers of the instruction to be offloaded.
 The offloading core may provide internal structures to facilitate multiple instructions to be issued independently, resulting in a pseudo multi-issue pipeline.
 
 ### Memory Operations
@@ -86,16 +86,16 @@ The core-v-xif defines two distinct modes of memory access for external accelera
   For this purpose, external mode memory operations are defined.
 
 ## Interface Subset Naming Convention
-The naming scheme to describe the subset of optional features included in a hardware implementation of the core-v-xif implementation comprises the following components.
+The naming scheme to describe the subset of optional features included in a hardware implementation of the core-v-xif implementation comprises the following components:
 
-| Component | Description                                   |
-| --------- | -----------                                   |
-| core-v-xifv[X]   | core-v-xif Version [X] of the specification draft    |
-| XLEN      | Base ISA bit width                            |
-| T         | Support for ternary operations                |
-| D         | Support for dual-writeback instructions       |
-| M         | Support for 'internal mode' memory operations |
-| E         | Support for 'external mode' memory operations |
+| Component      | Description                                       |
+| -------------- | ------------------------------------------------- |
+| core-v-xifv[X] | core-v-xif Version [X] of the specification draft |
+| XLEN           | Base ISA bit width                                |
+| T              | Support for ternary operations                    |
+| D              | Support for dual-writeback instructions           |
+| M              | Support for 'internal mode' memory operations     |
+| E              | Support for 'external mode' memory operations     |
 
 The specification version indicator is separated from the rest of the description string by an underscore (`_`).
 For example, a hardware implementation of the spec version 0.1 (this version) based on a 32 bit core supporting ternary operations and internal mode memory operations would be described with `core-v-xifv0.1_32TM`.

--- a/doc/operating-principle.md
+++ b/doc/operating-principle.md
@@ -9,10 +9,10 @@ Upon encountering an instruction in the instruction decoder which it is not able
 ### Core-Adapter Offloading Handshake
 Offloaded instructions can not be retracted by the offloading core once they have been accepted by the accelerator adapter.
 It is therefore essential, that any instructions present in the offloading core's pipeline are guaranteed to not raise any exceptions that might require invalidation of the results produced by the offloaded instruction.
-In particular, an instrucion may not be offloaded if there is a memory operation pending in either the core's pipeline or any of the connected accelerator units.
+In particular, an instruction may not be offloaded if there is a memory operation pending in either the core's pipeline or any of the connected accelerator units.
 The memory operation status of connected accelerators is tracked by the accelerator adapter and provided to the core via the asynchronous status signal `adapter_mem_pending`.
 
-Once there are no such conflicts possible, the offloading core initiates the offload request transaction by asserting it's `x.q_valid` line on the [X instruction offloading interface](x-interface.md).
+Once there are no such conflicts possible, the offloading core initiates the offload request transaction by asserting its `x.q_valid` line on the [X instruction offloading interface](x-interface.md).
 
 It exposes the RISC-V instruction data to the accelerator adapter using the `x.q_instr_data` signal.
 The source register addresses for `rs1` through `rs3` are encoded invariantly by bits `instr_data[19:15]`, `instr_data[24:20]` and `instr_data[31:27]`.
@@ -50,7 +50,7 @@ If the instruction only impacts the accelerator's internal architectural state, 
 ### Offload Instruction Response
 The offloaded instruction returns a response for
 - Regular integer register file writebacks (Response Type `1'b0`).
-  The offload response carries wrieteback data along with the target destination register.
+  The offload response carries writeback data along with the target destination register.
 - External mode synchronous memory operations (Response Type `1'b1`) See [Synchronous Memory Operations](#synchronous-memory-operations) for details.
 
 ### Memory operations
@@ -64,7 +64,7 @@ Furthermore, offloaded memory operations are classified with the following attri
   Access faults resulting from synchronous memory operations are trapped precisely by the offloading core.
   Neither the offloading core nor any of the connected accelerators may commit any new instruction results while synchronous memory operations are being served.
 - *Speculative* memory operations do not automatically trigger exceptions in the offloading core upon encountering access faults.
-  The success or failure of a speculative memory operation is reported by the accelerator upon completion of the instruciton.
+  The success or failure of a speculative memory operation is reported by the accelerator upon completion of the instruction.
 - *Asynchronous* memory operations execute in parallel to the main instruction stream.
   Memory access permissions are probed via the defined memory interfaces before starting the memory operation.
   Once the necessary permissions are acquired by the accelerator, core pipeline is released to continue operation.
@@ -91,7 +91,7 @@ To enable the different flavors of memory operations, the memory operation pendi
     The number of required memory operations to serve an offloaded instruction is known to the issuing accelerator unit before the fact.
     As soon as the last operation associated with the offloaded instruction has been served, the offloading core may continue normal operation without requiring an additional response by the accelerator unit.
   - *Asynchronous external mode* memory transactions: The accelerator unit must probe the memory region in question for permission before independently issuing its memory operations.
-    By setting the `q_endoftransaction` signal associated with this probing request, the core pipeline is released to continue operation in parallel with the accelerator unit issuing it's asynchronous requests.
+    By setting the `q_endoftransaction` signal associated with this probing request, the core pipeline is released to continue operation in parallel with the accelerator unit issuing its asynchronous requests.
 - An explicit memory response packet (marked by `c.p_type`) is sent from the accelerator unit to the offloading core.
   In addition to ending the transaction, the C-response packet carries any relevant information on the success or failure status of the associated instruction.
   This mechanisms can be used for
@@ -100,7 +100,7 @@ To enable the different flavors of memory operations, the memory operation pendi
     As the last memory operation is not known at request time, Cmem-request may not be marked to end the sequence.
     Instead the accelerator unit may explicitly end the memory operations.
   - *Synchronous external mode* memory transactions:
-    The accelerator unit performs memory opertions independently of the offloading core.
+    The accelerator unit performs memory operations independently of the offloading core.
     The core is explicitly informed of the end of such a memory operation and its success/failure status.
 
 The following subsections describe the transaction process for internal and external mode memory operations in some more detail.
@@ -108,16 +108,16 @@ The following subsections describe the transaction process for internal and exte
 #### Internal Mode
 The standard mode for accessing memories for extension accelerators is through the offloading core's load/store unit.
 This brings several advantages as compared to accelerator-private memory interfaces:
-- Memory accesses are routed through the processor's data cache, thus reducing cache coherency hardware- and performance overheads.
+- Memory accesses are routed through the processor's data cache, thus reducing cache coherency hardware and performance overheads.
 - Sharing the offloading core's memory infrastructure, simplifies coherent address translation, permission checks and precise exception handling.
-- Through the detailed specification of instruction offloading *and* memory interfaces, the RISC-V extension interface becomes truely plug-and-play for accelerators implementing this memory operation mode.
+- Through the detailed specification of instruction offloading *and* memory interfaces, the RISC-V extension interface becomes truly plug-and-play for accelerators implementing this memory operation mode.
 
 An internal-mode memory transaction is triggered by an offload request implying a load or store memory access being accepted by the accelerator adapter.
 The memory operation is identified by the accelerator predecoders, the offloading core is informed of the pending memory request through the X-interface signal `x.k_is_mem_op`.
 
 > At this point and until the status signal is reset, the core is not allowed to commit any subsequent instructions.
 > Speculative execution may continue internally, if the core implements roll-back in case of an access fault occuring.
-> Further instruction offload requests may not be issued to the accelerator adapter while there is an offloaded memory operation pendin, since there is no means to retract any offloaded instructions in case the result must be invalidated.
+> Further instruction offload requests may not be issued to the accelerator adapter while there is an offloaded memory operation pending, since there is no means to retract any offloaded instructions in case the result must be invalidated.
 > The offloaded instruction's program counter must be stored by the offloading core for possible exception handling upon access faults.
 
 The offload request is forwarded to the accelerator subsystem via the C-interface.
@@ -125,22 +125,22 @@ The accelerator subsystem decodes the instructions and determines memory address
 
 The accelerator unit set the appropriate signals on the C-Mem request channel and asserts `q_valid` to initiate a transaction:
 - `cmem.q_laddr` designates the target logical memory address.
-  This signal is fowarded to the offloading core via the X-Mem interface.
+  This signal is forwarded to the offloading core via the X-Mem interface.
 - `cmem.q_wdata` carries memory write data if this is a store transaction and `'0` otherwise.
-  This signal is fowarded to the offloading core via the X-Mem interface.
+  This signal is forwarded to the offloading core via the X-Mem interface.
 - `cmem.q_width` specifies the width of the memory access.
   The width of a memory transaction is limited by the processor's internal bit width.
   If wider ranges of data are needed to serve a memory instruction, multiple requests must be issued in sequence.
-  This signal is fowarded to the offloading core via the X-Mem interface.
+  This signal is forwarded to the offloading core via the X-Mem interface.
 - `cmem.q_req_type` specifies the request type (execute, write or read).
-  This signal is fowarded to the offloading core via the X-Mem interface.
+  This signal is forwarded to the offloading core via the X-Mem interface.
 - `cmem.q_mode` is set to `1'b0` for standard memory operations.
-  This signal is fowarded to the offloading core via the X-Mem interface.
+  This signal is forwarded to the offloading core via the X-Mem interface.
 - `cmem.q_spec` marks speculative memory operations.
   If asserted, the offloading core will not raise an exception upon encountering an access fault.
-  This signal is fowarded to the offloading core via the X-Mem interface.
+  This signal is forwarded to the offloading core via the X-Mem interface.
 - `cmem.q_endoftransaction` designates the last in a series of memory request pertaining to the same offloaded memory instruction.
-  This signal is used only for book-keeping by the accelerator adapter and is *not* fowarded to the offloading core accross the X-Mem interface.
+  This signal is used only for book-keeping by the accelerator adapter and is *not* forwarded to the offloading core accross the X-Mem interface.
 - `cmem.q_hart_id` the processor core's hart ID is used for routing the C-Mem request accross the accelerator interconnect.
   This signal is *not* forwarded to the offloading core accross the X-Mem interface.
 
@@ -148,13 +148,13 @@ The accelerator adapter forwards the C-Mem request to the offloading core via th
 The offloading core is aware of an outstanding memory request by the accelerator adapter due to the `adapter_mem_pending` status signal and provides control over the the internal load/store unit to the adapter.
 The X-Mem request channel payload signals comprise the signals `q_laddr`, `q_wdata`, `q_width`, `q_req_type`, `q_mode` and `q_spec`.
 
-The X-Mem request payload data is transfered to the offloading core's LSU and acknowleged by the core via the `xmem.q_ready` signal in the same cycle as the memory response transaction is initiated:
+The X-Mem request payload data is transfered to the offloading core's LSU and acknowledged by the core via the `xmem.q_ready` signal in the same cycle as the memory response transaction is initiated:
 - The offloading core asserts `xmem.q_ready` to complete the memory request transaction and simultaneously initiates a memory response transaction by asserting `xmem.p_valid`.
 - `xmem.p_rdata` carries the loaded memory contents if the access was a load operation.
   For store operations the signal is assigned `'0`.
 - `xmem.p_range` is unused for standard mode memory operations. it is assigned `'0`.
 - `xmem.p_status` indicates success (`p_status = 1'b1`) or failure (`p_status = 1'b0`) of the memory operation.
-The response transaction is acknowleged by the accelerator adapter by asserting the `xmem.p_ready` signal and sent across the accelerator interconnect to the accelerator unit via the C-Mem response channel.
+The response transaction is acknowledged by the accelerator adapter by asserting the `xmem.p_ready` signal and sent across the accelerator interconnect to the accelerator unit via the C-Mem response channel.
 
 
 > Any memory operations issued by the accelerator units traverse all implemented PMP and PMA checks as well address translation in the offloading core as would be the case for core-internal memory operations.
@@ -177,26 +177,26 @@ Similarly to internal mode memory operations, external mode memory operations bl
 The accelerator unit sets the C-Mem request channel signals as follows:
 
 - `cmem.q_laddr` designates the target logical memory address.
-  This signal is fowarded to the offloading core via the X-Mem interface.
+  This signal is forwarded to the offloading core via the X-Mem interface.
 - `cmem.q_wdata` is unused for external mode memory requests and is assigned `'0`.
-  This signal is fowarded to the offloading core via the X-Mem interface.
+  This signal is forwarded to the offloading core via the X-Mem interface.
 - `cmem.q_width` unused for external mode memory requests and is assigned `'0`.
-  This signal is fowarded to the offloading core via the X-Mem interface.
+  This signal is forwarded to the offloading core via the X-Mem interface.
 - `cmem.q_req_type` specifies the request type (execute, write or read).
-  This signal is fowarded to the offloading core via the X-Mem interface.
+  This signal is forwarded to the offloading core via the X-Mem interface.
 - `cmem.q_mode` is set to `1'b1` for probing the memory  memory operations.
-  This signal is fowarded to the offloading core via the X-Mem interface.
+  This signal is forwarded to the offloading core via the X-Mem interface.
 - `cmem.q_endoftransaction` signals to the accelerator adapter to lift the `adapter_mem_pending` status signal and releases the blocking of the core's pipeline.
-  This signal is used only for book-keeping by the accelerator adapter and is *not* fowarded to the offloading core accross the X-Mem interface.
+  This signal is used only for book-keeping by the accelerator adapter and is *not* forwarded to the offloading core accross the X-Mem interface.
 - `cmem.q_hart_id` the processor core's hart ID is used for routing the C-Mem request accross the accelerator interconnect.
   This signal is used only for request signal routing from the accelerator unit to the adapter and is *not* forwarded to the offloading core accross the X-Mem interface.
 
-The X-Mem request payload data is transfered to the offloading core's PMP/PMA/MMU infrastructure and acknowleged by the core via the `xmem.q_ready` signal in the same cycle as the memory response transaction is initiated:
+The X-Mem request payload data is transferred to the offloading core's PMP/PMA/MMU infrastructure and acknowledged by the core via the `xmem.q_ready` signal in the same cycle as the memory response transaction is initiated:
 The response channel carries the following information:
 - `xmem.p_rdata` carries the corresponding physical memory address.
 - `xmem.p_range` specifies the number of LSB bits that can be changed in the logical address without changing the metadata.
 - `xmem.p_status` indicates if the requested access to the specified memory region is granted.
-The response transaction is acknowleged by the accelerator adapter by asserting the `xmem.p_ready` signal and sent across the accelerator interconnect to the accelerator unit via the C-Mem response channel.
+The response transaction is acknowledged by the accelerator adapter by asserting the `xmem.p_ready` signal and sent across the accelerator interconnect to the accelerator unit via the C-Mem response channel.
 
 External mode memory requests resulting in an access *not granted response* trigger a precise trap of the offending instruction in the core's pipeline.
 
@@ -218,7 +218,7 @@ The memory operation instruction response is encoded as follows:
 If an external synchronous memory operation has not been successful, the offloading core must trap using the corresponding instruction PC and the offending address transmitted via the C-interface.
 
 ## Fence Instructions
-Fence instructions are handled entirely without direct partizipation of the accelerator adapter.
+Fence instructions are handled entirely without direct participation of the accelerator adapter.
 Upon encountering a fence instruction, the offloading core must wait until any outstanding integer writeback instructions have returned their responses and until the `adapter_mem_pending` signal is deasserted.
 Synchronization with external asynchronous memory operations must be handled explicitly.
 

--- a/doc/x-interface.md
+++ b/doc/x-interface.md
@@ -4,7 +4,7 @@ The X-Interface implements accelerator-agnostic instruction offloading and trans
 ## Interface Definition
 The X-Interface defines in total four independent decoupled channels communication between the accelerator adapter and the offloading processor core.
 The X-Request and X-Response channels route instruction offloading requests and accelerator writeback responses.
-The XMem-Request and XMem-Reponse channels route memory transaction requests and responses.
+The XMem-Request and XMem-Response channels route memory transaction requests and responses.
 
 The X and XMem SystemVerilog interfaces are separately defined as independent entities.
 Request channel signals are prefixed with the letter `q`.
@@ -27,7 +27,7 @@ The interface is parameterized using the following set of parameters.
 
 #### Derived Parameters
 | Name    | Value                   | Description                                 |
-| ----    | -----                   | -----------                                 |
+| ------- | ----------------------- | ------------------------------------------- |
 | `NumRs` | `TernaryOps ? 3 : 2`    | Supported number of source registers        |
 | `NumWb` | `DualWriteback ? 2 : 1` | Supported number of simultaneous writebacks |
 
@@ -35,7 +35,7 @@ The interface is parameterized using the following set of parameters.
 #### X-Request Channel
 The request channel signals are:
 | Signal Name       | Type                    | Direction      | Description                                                |
-| -----------       | -----                   | ---------      | -----------                                                |
+| ----------------- | ----------------------- | -------------- | ---------------------------------------------------------- |
 | `q_instr_data`    | `logic [31:0]`          | Core > Adapter | Instruction data (ID stage)                                |
 | `q_rs[NumRs-1:0]` | `logic [DataWidth-1:0]` | Core > Adapter | Source register contents                                   |
 | `q_rs_valid`      | `logic [NumRs-1:0]`     | Core > Adapter | Source register valid indicator                            |
@@ -71,11 +71,11 @@ The instruction offloading process takes place according to the following scheme
 The response channel signals are:
 
 | Signal Name       | Type                    | Direction      | Description                                                                   |
-| -----------       | -----                   | ---------      | -----------                                                                   |
+| ----------------- | ----------------------- | -------------- | ----------------------------------------------------------------------------- |
 | `p_rd`            | `logic [4:0]`           | Adapter > Core | Destination register address                                                  |
 | `p_data[NumWb:0]` | `logic [DataWidth-1:0]` | Adapter > Core | Instruction response data                                                     |
 | `p_dualwb`        | `logic`                 | Adapter > Core | Dual-Writeback response (constant `1'b0`, if dual-writeback is not supported) |
-| `p_type`          | `logic`                 | Adapter > Core | Response type
+| `p_type`          | `logic`                 | Adapter > Core | Response type                                                                 |
 | `p_error`         | `logic`                 | Adapter > Core | Error flag                                                                    |
 
 Notes:
@@ -99,7 +99,7 @@ Notes:
 The request channel signals from the adapter to the offloading core are:
 
 | Signal Name          | Type                    | Direction      | Description                                               |
-| -----------          | ----                    | ---------      | -----------                                               |
+| -------------------- | ----------------------- | -------------- | --------------------------------------------------------- |
 | `q_laddr`            | `logic [DataWidth-1:0]` | Adapter > Core | Target logical memory address                             |
 | `q_wdata`            | `logic [DataWidth-1:0]` | Adapter > Core | Memory write data                                         |
 | `q_width`            | `logic [1:0]`           | Adapter > Core | Memory access width (byte, half-word, word, [...])        |
@@ -113,7 +113,7 @@ The request channel signals from the adapter to the offloading core are:
 The response channel signals from the offloading core to the adapter are:
 
 | Signal Name | Type                           | Direction             | Description                           |
-| ----------- | ----                           | ---------             | -----------                           |
+| ----------- | ------------------------------ | --------------------- | ------------------------------------- |
 | `p_rdata`   | `logic [DataWidth-1:0]`        | Core > Adapter        | Memory response data.                 |
 | `p_range`   | `logic [clog2(DataWidth)-1:0]` | Core > Adapter        | Validity LSB range of memory metadata |
 | `p_status`  | `logic`                        | Core > Adapter        | Transaction status (success / fail)   |
@@ -122,7 +122,7 @@ Notes:
   - The response transaction status `p_status` field indicates the success (`p_status = 1'b1`) or failure (`p_status = 1'b0`) of the memory operation.
       - For standard requests, the status field indicates if the operation raised an access fault exception.
       - For probing memory requests, the status field indicates if the requested access has been granted.
-  - The `p_range` field carries information on the memory region querried with a probing memory request.
+  - The `p_range` field carries information on the memory region queried with a probing memory request.
     If the `p_status` field signals access has been granted, this field specifies the number of bits that can be changed in the logical address without changing the metadata
 
 ## Master/Slave Interface Ports

--- a/test/acc_interconnect_tb.sv
+++ b/test/acc_interconnect_tb.sv
@@ -496,7 +496,7 @@ module acc_interconnect_tb  #(
 
   // C Response Path
   // ---------------
-  // Map each C reponse observed at the core response output to a response generated at the
+  // Map each C response observed at the core response output to a response generated at the
   // accelerator response input port.
   initial begin
     scoreboard_tracker::nr_c_responses = 0;
@@ -623,7 +623,7 @@ module acc_interconnect_tb  #(
       join_none
     end
 
-    // Check fowarded responses
+    // Check forwarded responses
     for (int jj=0; jj<NumReq; jj++) begin
       automatic int j = jj; // forwarding port ID
       fork


### PR DESCRIPTION
Hi!
Here are some minor typos I noticed while skimming through the specs.
The PR also includes changes to `markdown` table to fix a couple of formatting issues and make easier to follow when reading/editing in a text-only mode. It also adds `sv` language identifier for proper highlighting of in-lined SystemVerilog code (It should work with GitHub markdown, as well many other editors and tools supporting the GitHub dialect).
Hope it's gonna be useful :)
Thanks for the great work!