### PR TITLE
Update cv32e40x if_xif url

### DIFF
--- a/docs/source/x_ext.rst
+++ b/docs/source/x_ext.rst
@@ -291,7 +291,7 @@ A SystemVerilog interface implementation for CORE-V-XIF could look as follows:
 
   endinterface : if_xif
 
-A full reference implementation of the SystemVerilog interface can be found at https://github.com/openhwgroup/cv32e40x/blob/master/rtl/if_xif.sv.
+A full reference implementation of the SystemVerilog interface can be found at https://github.com/openhwgroup/cv32e40x/blob/master/rtl/cv32e40x_if_xif.sv.
 
 
 Identification


### PR DESCRIPTION
The previous url is no longer valid. This PR updates to the correct url.
 
Moreover, it does not follow the latest version of the specs (for example there are no `X_DUALREAD` or `X_DUALWRITE` parameters. Should we add a note/warning about this?