### PR TITLE
Remove redundant sentence in result interface

### DIFF
--- a/docs/source/x_ext.rst
+++ b/docs/source/x_ext.rst
@@ -918,8 +918,6 @@ If `ecswe[1]`` is 1, then the value in ``ecsdata[3:2]`` is written to ``mstatus.
 If `ecswe[0]`` is 1, then the value in ``ecsdata[1:0]`` is written to ``mstatus.vs``.
 The writes to the stated ``mstatus`` bitfields will take into account any WARL rules that might exist for these bitfields in the |processor|.
 
-The signals in ``result`` are valid when ``result_valid`` is 1. These signals remain stable during a result transaction.
-
 Interface dependencies
 ----------------------
 


### PR DESCRIPTION
This same sentence is repeated a few paragraphs before: https://github.com/openhwgroup/core-v-xif/blob/9a4cc2ab574f08f1fe08b8abe24e64822d2bbeeb/docs/source/x_ext.rst?plain=1#L896-L897