### PR TITLE
Removing deprecated method

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -121,9 +121,6 @@ html_css_files = [
   'css/custom.css',
 ]
 
-def setup(app):
-   app.add_stylesheet('css/custom.css')
-
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.


### PR DESCRIPTION
html_css_files statement is already there and seems to be the most compatible