### PR TITLE
Cleaning up intro

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -10,7 +10,7 @@ The goal of ``CORE-V-XIF`` is to enable the design and verification of instructi
 
 License
 -------
-Copyright 2021-2023 OpenHW Group.
+Copyright 2021-2024 OpenHW Group.
 
 SPDX-License-Identifier: Apache-2.0 WITH SHL-0.51
 
@@ -19,19 +19,7 @@ Standards Compliance
 
 The ``eXtension interface`` specification depends on the following specifications:
 
-.. [RISC-V-UNPRIV] RISC-V Instruction Set Manual, Volume I: User-Level ISA, Document Version 20191213 (December 13, 2019),
-   https://github.com/riscv/riscv-isa-manual/releases/download/Ratified-IMAFDQC/riscv-spec-20191213.pdf
-
-Contents
---------
-
- * :ref:`x_ext` describes the custom eXtension interface.
-
-History
--------
-
-References
-----------
-
-Contributors
-------------
+.. [RISC-V-UNPRIV] The RISC-V Instruction Set Manual, Volume I: User-Level ISA,
+   Document Version 20191213”, Editors Andrew Waterman and Krste Asanovi´c, RISC-V Foundation, December 2019.
+.. [RISC-V-PRIV] The RISC-V Instruction Set Manual, Volume II: Privileged Architecture,
+   Document Version 20211203”, Editors Andrew Waterman, Krste Asanovi´c, and John Hauser, RISC-V International, December 2021.

--- a/docs/source/x_ext.rst
+++ b/docs/source/x_ext.rst
@@ -484,7 +484,7 @@ Typically an accepted transaction over the compressed interface will be followed
 on the |processor| to do so (as the instructions offloaded over the compressed interface and issue interface are allowed to be speculative). Only when an ``accept``
 is signaled over the *issue* interface, then an instruction is considered *accepted for offload*. 
 
-The |coprocessor| shall not take the ``mstatus`` based extension context status into account when generating the ``accept`` signal on its *compressed* interface (but it shall take
+The |coprocessor| shall not take the ``mstatus`` based extension context status (see ([RISC-V-PRIV]_)) into account when generating the ``accept`` signal on its *compressed* interface (but it shall take
 it into account when generating the ``accept`` signal on its *issue* interface).
 
 Issue interface
@@ -550,7 +550,7 @@ The ``instr`` signal remains stable during an issue request transaction.
 
   The ``mode`` signal remains stable during an issue request transaction.
 
-  ``mode`` is the effective privilege level. That means that this already accounts for settings of ``mstatus.MPRV`` = 1.
+  ``mode`` is the effective privilege level as defined in [RISC-V-UNPRIV]_. That means that this already accounts for settings of ``mstatus.MPRV`` = 1.
   As coprocessors must be unprivileged, the mode signal may only be used in memory transactions.
 
 :numref:`Issue response type` describes the ``x_issue_resp_t`` type.


### PR DESCRIPTION
- proper RISC-V references
- removing empty sections
- updating copyright to 2024