### PR TITLE
Fixing copyright holder of conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,4 @@
-# Copyright 2024 OpenHW Group
+# Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 # Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may not use this file except in compliance with the License, or, at your option, the Apache License version 2.0.
 # You may obtain a copy of the License at https://solderpad.org/licenses/SHL-2.1/


### PR DESCRIPTION
- contribution was made by NXP, but incorrectly attributed to OpenHW Group