### PR TITLE
Improving X_MISA parameter

### DIFF
--- a/docs/source/x_ext.rst
+++ b/docs/source/x_ext.rst
@@ -84,6 +84,7 @@ The CV-X-IF specification contains the following parameters:
   +------------------------------+------------------------+---------------+--------------------------------------------------------------------+
 
 The |processor| shall set the ``misa.Extensions`` field to a value that is the result of an or operation of its own Extensions and the ``X_MISA`` parameter.
+Not all bits of ``misa.Extensions`` will be legal for a coprocessor to set, e.g. if this extension is already implemented in the |processor| or if it is an extension not possible to implement as part of a coprocessor like privileged extensions.
 
 .. only:: MemoryIf
 

--- a/docs/source/x_ext.rst
+++ b/docs/source/x_ext.rst
@@ -65,7 +65,7 @@ The CV-X-IF specification contains the following parameters:
   |                              |                        |               | to MXLEN.                                                          |
   |                              |                        |               | The |processor| determines the legal values for this parameter.    |
   +------------------------------+------------------------+---------------+--------------------------------------------------------------------+
-  | ``X_MISA``                   | logic [31:0]           | 32'b0         | MISA extensions implemented on the eXtension interface.            |
+  | ``X_MISA``                   | logic [25:0]           | 32'b0         | MISA extensions implemented on the eXtension interface.            |
   |                              |                        |               | The |processor| determines the legal values for this parameter.    |
   +------------------------------+------------------------+---------------+--------------------------------------------------------------------+
   | ``X_ECS_XS``                 | logic [1:0]            | 2'b0          | Initial value for ``mstatus.XS``.                                  |
@@ -82,6 +82,8 @@ The CV-X-IF specification contains the following parameters:
   |                              |                        |               | If 1, registers are provided after the issue of the instruction.   |
   |                              |                        |               | If 0, registers are provided at the same time as issue.            |
   +------------------------------+------------------------+---------------+--------------------------------------------------------------------+
+
+The |processor| shall set the ``misa.Extensions`` field to a value that is the result of an or operation of its own Extensions and the ``X_MISA`` parameter.
 
 .. only:: MemoryIf
 

--- a/src/core_v_xif.sv
+++ b/src/core_v_xif.sv
@@ -32,7 +32,7 @@ interface core_v_xif
   parameter int unsigned X_RFW_WIDTH            = 32, // Register file write access width for the eXtension interface
   parameter int unsigned X_NUM_HARTS            = 1,  // Number of harts (hardware threads) associated with the interface
   parameter int unsigned X_HARTID_WIDTH         = 1,  // Width of ``hartid`` signals.
-  parameter logic [31:0] X_MISA                 = '0, // MISA extensions implemented on the eXtension interface
+  parameter logic [25:0] X_MISA                 = '0, // MISA extensions implemented on the eXtension interface
   parameter logic [ 1:0] X_ECS_XS               = '0, // Initial value for mstatus.XS
   parameter int unsigned X_DUALREAD             = 0,  // Is dual read supported? 0: No, 1: Yes, for ``rs1``, 2: Yes, for ``rs1`` - ``rs2``, 3: Yes, for ``rs1`` - ``rs3``
   parameter int unsigned X_DUALWRITE            = 0,  // Is dual write supported? 0: No, 1: Yes.


### PR DESCRIPTION
- clarifying what a CPU is expected to do with this parameter
- Adjusting the range of the paramter
  - old range was 32:0
  - range according to RV spec is MXLEN-1:0
  - new range is 25:0, as this is where the Extensions field is