### PR TITLE
Moving key configuration to pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ It features independent channels for accelerator-agnostic offloading of instruct
 
 ## Configuration
 
-The project is configured using the pyproject.toml file. Its values are input to docs/conf.py for building the documentation.
+The project is configured using the [pyproject.toml](./pyproject.toml) file. Its values are input to [docs/source/conf.py](./docs/source/conf.py) for building the documentation.
 
 When updating the project, it should be ensured that the configuration is up to date. In particular, version and copyright should be checked.
 
-The specification uses semantic versioning (see [https://semver.org/](https://semver.org/)). 
+The specification uses semantic versioning (see [https://semver.org/](https://semver.org/)).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ The Core-V eXtension interface (CV-X-IF) is a RISC-V eXtension interface that pr
 
 It features independent channels for accelerator-agnostic offloading of instructions and writeback of the result(s).
 
+## Configuration
+
+The project is configured using the pyproject.toml file. Its values are input to docs/conf.py for building the documentation.
+
+When updating the project, it should be ensured that the configuration is up to date. In particular, version and copyright should be checked.
+
+The specification uses semantic versioning (see [https://semver.org/](https://semver.org/)). 
+
 ## Documentation
 
 The CV-X-IF user manual can be found in the _docs_ folder and it is

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx
 sphinx-rtd-theme
 sphinxcontrib-svg2pdfconverter
 sphinx_github_changelog
+sphinx-pyproject>=0.3.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,11 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
+# -- pyproject integration ---------------------------------------------------
+
+from sphinx_pyproject import SphinxConfig
+config = SphinxConfig("../../pyproject.toml", globalns=globals())
+
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -23,52 +28,28 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-# -- Specification Process Data -----------------------------------------------
-
-states = (
-          'Development',
-          'Review',
-          'Release Candidate',
-          'Release',
-          )
-state_postfix = [
-                '-dev',
-                '-dev',
-                '-rc',
-                '',
-                ]
-
 title_prefix = 'OpenHW Group Specification'
 
 # -- Project information -----------------------------------------------------
 
-project = u'Core-V eXtension interface (CV-X-IF)'
-copyright = u'2021-2024 OpenHW Group'
-author = u'OpenHW Group'
-# State must be one of Development, Review, Release Candidate, or Release
-state = 'Release Candidate' 
-
-# The short vX.Y.Z version
-version = u'v1.0.0'
-# If release candidate, provide release candidate version (integer)
-rc_version = 1
+project = name
 
 # -- Derived Project Information - Do not modify ------------------------------
+version_elements = version.split('-')
+if len(version_elements) > 1:
+    if version_elements[1].startswith('rc'):
+        state = 'Release Candidate'
+    elif version_elements[1].startswith('dev'):
+        state = 'Development'
+else:
+    state = 'Release'
 
 if state == 'Release Candidate' or state == 'Release':
     if version[0] == '0':
         raise ValueError(f'Version {version} not allowed for state {state}.')
 
-postfix = state_postfix[states.index(state)]
-if state == 'Release Candidate':
-    postfix += f'.{rc_version}'
-
-# The full version, including alpha/beta/rc tags
-release = f'{version}{postfix}'
-version = release
-
 title = f'{title_prefix}: {project} - {state}'
-filename = f'{title_prefix}_{project}_{release}'.replace(' ', '_')
+filename = f'{title_prefix}_{project}_{version}'.replace(' ', '_')
 
 
 # -- General configuration ---------------------------------------------------
@@ -76,14 +57,6 @@ filename = f'{title_prefix}_{project}_{release}'.replace(' ', '_')
 # If your documentation needs a minimal Sphinx version, state it here.
 #
 # needs_sphinx = '1.0'
-
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
-extensions = [
-    'sphinxcontrib.inkscapeconverter',
-    'sphinx_github_changelog',
-]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['ytemplates']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "Core-V eXtension interface (CV-X-IF)"
+readme = "README.md"
+description = "RISC-V extension interface"
+requires-python = ">=3.9"
+version = "1.0.0-rc.1"
+
+[[project.authors]]
+name = "OpenHW Group"
+
+[tool.sphinx-pyproject]
+copyright = "2021-2024 OpenHW Group"
+extensions = [
+    'sphinxcontrib.inkscapeconverter',
+    'sphinx_github_changelog',
+]
+package_root = "docs"


### PR DESCRIPTION
This change isolated the configuration parameters from the more complicated settings within conf.py.
Normally, an editor of the specification should no longer have to edit conf.py.

This change is also a stepping stone towards having the version number generated at build time from the latest git tag.