### PR TITLE
Adding a note to explain the rational for offloading decompressed ins…

### DIFF
--- a/docs/source/x_ext.rst
+++ b/docs/source/x_ext.rst
@@ -544,6 +544,7 @@ Apart from the above two main scenarios a |processor| may also attempt to offloa
 (compressed/uncompressed) instructions that it does recognize as legal instructions itself. In case that both the |processor| and the |coprocessor| accept the same instruction as being valid,
 the instruction will cause an illegal instruction fault upon execution.
 
+In all cases, the |processor| must decode the instruction.
 The |processor| shall cause an illegal instruction fault when attempting to execute (commit) an instruction that:
 
 * is considered to be valid by the |processor| and accepted by the |coprocessor| (``accept`` = 1).


### PR DESCRIPTION
…tructions preferably to the coprocessor